### PR TITLE
Fixes #79

### DIFF
--- a/app/mailers/decidim/initiatives/initiatives_mailer.rb
+++ b/app/mailers/decidim/initiatives/initiatives_mailer.rb
@@ -39,7 +39,7 @@ module Decidim
             state: I18n.t(initiative.state, scope: 'decidim.initiatives.admin_states')
           )
 
-          @link = initiative_url(initiative)
+          @link = initiative_url(initiative, host: @organization.host)
 
           mail(to: "#{user.name} <#{user.email}>", subject: @subject)
         end
@@ -48,7 +48,7 @@ module Decidim
       # Notify an initiative requesting technical validation
       def notify_validating_request(initiative, user)
         @organization = initiative.organization
-        @link = decidim_admin_initiatives.edit_initiative_url(initiative)
+        @link = decidim_admin_initiatives.edit_initiative_url(initiative, host: @organization.host)
 
         with_user(user) do
           @subject = I18n.t(
@@ -67,7 +67,7 @@ module Decidim
       # Notify progress to all initiative subscribers.
       def notify_progress(initiative, user)
         @organization = initiative.organization
-        @link = initiative_url(initiative)
+        @link = initiative_url(initiative, host: @organization.host)
 
         with_user(user) do
           @body = I18n.t(

--- a/app/views/decidim/initiatives/initiatives_mailer/notify_creation.html.erb
+++ b/app/views/decidim/initiatives/initiatives_mailer/notify_creation.html.erb
@@ -1,6 +1,6 @@
 <p>
 <%=t 'decidim.initiatives.initiatives_mailer.creation_subject', title: partially_translated_attribute(@initiative.title) %>.
-<%= link_to t('decidim.initiatives.initiatives_mailer.more_information'), decidim.page_path('initiatives') %>
+<%= link_to t('decidim.initiatives.initiatives_mailer.more_information'), decidim.page_url('initiatives', host: @organization.host) %>
 </p>
 
 <% if @initiative.created_by_individual? %>
@@ -9,8 +9,8 @@
            member_count: Decidim::Initiatives.minimum_committee_members %>
     </p>
     <p>
-      <%= link_to decidim_initiatives.new_initiative_committee_request_url(@initiative),
-                  decidim_initiatives.new_initiative_committee_request_url(@initiative) %>
+      <%= link_to decidim_initiatives.new_initiative_committee_request_url(@initiative, host: @organization.host),
+                  decidim_initiatives.new_initiative_committee_request_url(@initiative, host: @organization.host) %>
     </p>
 <% end %>
 <br><br>
@@ -18,5 +18,5 @@
 <p>
   <%= t('check_initiative_details', scope: 'decidim.initiatives.initiatives_mailer.initiative_link') %>
   <%= link_to t('here',  scope: 'decidim.initiatives.initiatives_mailer.initiative_link'),
-              decidim_admin_initiatives.initiative_url(@initiative) %>
+              decidim_admin_initiatives.initiative_url(@initiative, host: @organization.host) %>
 </p>

--- a/bin/rails
+++ b/bin/rails
@@ -6,7 +6,7 @@
 
 ENGINE_ROOT = File.expand_path('../..', __FILE__)
 ENGINE_PATH = File.expand_path('../../lib/decidim/initiatives/engine', __FILE__)
-APP_PATH = File.expand.path('../../spec/decidim_dummy_app/config/application/', __FILE__)
+APP_PATH = File.expand_path('../../spec/decidim_dummy_app/config/application/', __FILE__)
 
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)


### PR DESCRIPTION
#### :tophat: What? Why?

Organization's host is passed to all url helpers used in mailers in order
to make links point to the right direction.

#### :pushpin: Related Issues
- Fixes #79 