### PR TITLE
Prevent duplicate votes

### DIFF
--- a/app/models/decidim/initiatives_vote.rb
+++ b/app/models/decidim/initiatives_vote.rb
@@ -7,10 +7,18 @@ module Decidim
   class InitiativesVote < ApplicationRecord
     include Decidim::PartialTranslationsHelper
 
-    belongs_to :author, foreign_key: 'decidim_author_id', class_name: 'Decidim::User'
-    belongs_to :user_group, foreign_key: 'decidim_user_group_id', class_name: 'Decidim::UserGroup', optional: true
+    belongs_to :author,
+               foreign_key: 'decidim_author_id',
+               class_name: 'Decidim::User'
 
-    belongs_to :initiative, foreign_key: 'decidim_initiative_id', class_name: 'Decidim::Initiative'
+    belongs_to :user_group,
+               foreign_key: 'decidim_user_group_id',
+               class_name: 'Decidim::UserGroup',
+               optional: true
+
+    belongs_to :initiative,
+               foreign_key: 'decidim_initiative_id',
+               class_name: 'Decidim::Initiative'
 
     validates :initiative, uniqueness: { scope: %i[author user_group] }
 

--- a/db/migrate/20171214161410_add_unique_on_votes.rb
+++ b/db/migrate/20171214161410_add_unique_on_votes.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddUniqueOnVotes < ActiveRecord::Migration[5.1]
+  def change
+    add_index :decidim_initiatives_votes,
+              %i[decidim_initiative_id decidim_author_id decidim_user_group_id],
+              unique: true,
+              name: 'decidim_initiatives_voutes_author_uniqueness_index'
+  end
+end

--- a/db/migrate/20171214161410_add_unique_on_votes.rb
+++ b/db/migrate/20171214161410_add_unique_on_votes.rb
@@ -1,9 +1,39 @@
+# This migration comes from decidim_initiatives (originally 20171214161410)
 # frozen_string_literal: true
 
 class AddUniqueOnVotes < ActiveRecord::Migration[5.1]
-  def change
+  def get_duplicates(*columns)
+    Decidim::InitiativesVote.select("#{columns.join(',')}, COUNT(*)").group(columns).having('COUNT(*) > 1')
+  end
+
+  def row_count(issue)
+    Decidim::InitiativesVote.where(
+      decidim_initiative_id: issue.decidim_initiative_id,
+      decidim_author_id: issue.decidim_author_id,
+      decidim_user_group_id: issue.decidim_user_group_id
+    ).count
+  end
+
+  def find_next(issue)
+    Decidim::InitiativesVote.find_by(
+      decidim_initiative_id: issue.decidim_initiative_id,
+      decidim_author_id: issue.decidim_author_id,
+      decidim_user_group_id: issue.decidim_user_group_id
+    )
+  end
+
+  def up
+    columns = %i[decidim_initiative_id decidim_author_id decidim_user_group_id]
+
+    get_duplicates(columns).each do |issue|
+      while row_count(issue) > 1 do
+        find_next(issue)&.destroy
+      end
+    end
+
+
     add_index :decidim_initiatives_votes,
-              %i[decidim_initiative_id decidim_author_id decidim_user_group_id],
+              columns,
               unique: true,
               name: 'decidim_initiatives_voutes_author_uniqueness_index'
   end


### PR DESCRIPTION
#### :tophat: What? Why?

Votes table validates for unique records in rails, but not in db schema. There might happen that duplicated votes/supports are accepted.

This might happen when 
#### :pushpin: Related Issues
- Fixes #81