### PR TITLE
Fixes #94

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    decidim-initiatives (0.2.6)
+    decidim-initiatives (0.2.7)
       decidim-admin
       decidim-comments
       decidim-core (~> 0.8.3)

--- a/app/views/decidim/initiatives/initiatives/_vote_cabin.html.erb
+++ b/app/views/decidim/initiatives/initiatives/_vote_cabin.html.erb
@@ -9,12 +9,12 @@
        data-reveal data-refresh-url="<%= signature_identities_initiative_url(slug: initiative.slug) %>">
   </div>
 <% else %>
-    <%= render partial: 'decidim/initiatives/initiatives/vote_button',
+    <%= render partial: "decidim/initiatives/initiatives/vote_button",
                locals: {
                    initiative: initiative,
-                   vote_label: t('.vote'),
-                   unvote_label: t('.already_voted')
-               } %>
+                   vote_label: t(".vote"),
+                   unvote_label: t(".already_voted")
+               } if Decidim::Initiatives.online_voting_allowed %>
 <% end %>
 
 <% if cannot?(:vote, initiative) && cannot?(:unvote, initiative) %>

--- a/lib/decidim/initiatives/version.rb
+++ b/lib/decidim/initiatives/version.rb
@@ -3,6 +3,6 @@
 module Decidim
   # This holds the decidim-initiatives version.
   module Initiatives
-    VERSION = "0.2.6"
+    VERSION = "0.2.7"
   end
 end

--- a/spec/controllers/decidim/initiatives/initiative_votes_controller_spec.rb
+++ b/spec/controllers/decidim/initiatives/initiative_votes_controller_spec.rb
@@ -16,13 +16,9 @@ module Decidim
 
       context "when POST create" do
         context "and Authorized users" do
-          before do
-            initiative.author.confirm
-            sign_in initiative.author, scope: :user
-          end
-
           it "Authorized users can vote" do
             expect do
+              sign_in initiative.author, scope: :user
               post :create, params: { initiative_slug: initiative.slug, format: :js }
             end.to change { InitiativesVote.where(initiative: initiative).count }.by(1)
           end
@@ -31,11 +27,8 @@ module Decidim
         context "and Non authorized users" do
           let(:user) { create(:user, :confirmed, organization: initiative.organization) }
 
-          before do
-            sign_in user, scope: :user
-          end
-
           it "raise an exception" do
+            sign_in user, scope: :user
             post :create, params: { initiative_slug: initiative.slug, format: :js }
             expect(flash[:alert]).not_to be_empty
             expect(response).to have_http_status(302)
@@ -43,6 +36,7 @@ module Decidim
 
           it "do not register the vote" do
             expect do
+              sign_in user, scope: :user
               post :create, params: { initiative_slug: initiative.slug, format: :js }
             end.not_to(change { InitiativesVote.where(initiative: initiative).count })
           end
@@ -66,15 +60,11 @@ module Decidim
         let!(:vote) { create(:initiative_user_vote, initiative: initiative, author: initiative.author) }
 
         context "and authorized users" do
-          before do
-            initiative.author.confirm
-            sign_in initiative.author, scope: :user
-          end
-
           it "Authorized users can unvote" do
             expect(vote).not_to be_nil
 
             expect do
+              sign_in initiative.author, scope: :user
               delete :destroy, params: { initiative_slug: initiative.slug, format: :js }
             end.to change { InitiativesVote.where(initiative: initiative).count }.by(-1)
           end

--- a/spec/features/admin/admin_manages_initiative_features_spec.rb
+++ b/spec/features/admin/admin_manages_initiative_features_spec.rb
@@ -8,10 +8,13 @@ describe "Admin manages initiative features", type: :feature do
 
   let!(:initiative) { create(:initiative, organization: organization) }
 
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+  end
+
   context "when adds a feature" do
     before do
-      switch_to_host(organization.host)
-      login_as user, scope: :user
       visit decidim_admin_initiatives.features_path(initiative)
 
       find("button[data-toggle=add-feature-dropdown]").click
@@ -90,8 +93,6 @@ describe "Admin manages initiative features", type: :feature do
     end
 
     before do
-      switch_to_host(organization.host)
-      login_as user, scope: :user
       visit decidim_admin_initiatives.features_path(initiative)
     end
 
@@ -154,8 +155,6 @@ describe "Admin manages initiative features", type: :feature do
     end
 
     before do
-      switch_to_host(organization.host)
-      login_as user, scope: :user
       visit decidim_admin_initiatives.features_path(initiative)
     end
 

--- a/spec/features/admin/attachment_management_spec.rb
+++ b/spec/features/admin/attachment_management_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 require "decidim/admin/test/manage_attachments_examples"
 
 describe "initiative attachments", type: :feature do
-  context "when managed by admin" do
+  describe "when managed by admin" do
     include_context "when admins initiative"
 
     let(:attached_to) { initiative }
@@ -19,7 +19,7 @@ describe "initiative attachments", type: :feature do
     it_behaves_like "manage attachments examples"
   end
 
-  context "when managed by author" do
+  describe "when managed by author" do
     include_context "when admins initiative"
 
     let(:attached_to) { initiative }

--- a/spec/shared/create_initiative_example.rb
+++ b/spec/shared/create_initiative_example.rb
@@ -1,32 +1,30 @@
 # frozen_string_literal: true
 
-shared_examples 'create an initiative' do
+shared_examples "create an initiative" do
   let(:scoped_type) { create(:initiatives_type_scope) }
   let(:author) { create(:user, organization: scoped_type.type.organization) }
   let(:form) { form_klass.from_params(form_params).with_context(current_organization: scoped_type.type.organization) }
 
-  describe 'call' do
+  describe "call" do
     let(:form_params) do
       {
-        title: 'A reasonable initiative title',
-        description: 'A reasonable initiative description',
+        title: "A reasonable initiative title",
+        description: "A reasonable initiative description",
         type_id: scoped_type.type.id,
-        signature_type: 'online',
+        signature_type: "online",
         scope_id: scoped_type.scope.id,
         decidim_user_group_id: nil
       }
     end
 
-    let(:command) do
-      described_class.new(form, author)
-    end
+    let(:command) { described_class.new(form, author) }
 
-    describe 'when the form is not valid' do
+    describe "when the form is not valid" do
       before do
         expect(form).to receive(:invalid?).and_return(true)
       end
 
-      it 'broadcasts invalid' do
+      it "broadcasts invalid" do
         expect { command.call }.to broadcast(:invalid)
       end
 
@@ -37,32 +35,32 @@ shared_examples 'create an initiative' do
       end
     end
 
-    describe 'when the form is valid' do
-      it 'broadcasts ok' do
+    describe "when the form is valid" do
+      it "broadcasts ok" do
         expect { command.call }.to broadcast(:ok)
       end
 
-      it 'creates a new initiative' do
+      it "creates a new initiative" do
         expect do
           command.call
         end.to change { Decidim::Initiative.count }.by(1)
       end
 
-      it 'sets the author' do
+      it "sets the author" do
         command.call
         initiative = Decidim::Initiative.last
 
         expect(initiative.author).to eq(author)
       end
 
-      it 'Default state is created' do
+      it "Default state is created" do
         command.call
         initiative = Decidim::Initiative.last
 
-        expect(initiative.created?).to be_truthy
+        expect(initiative).to be_created
       end
 
-      it 'Title and description are stored with its locale' do
+      it "Title and description are stored with its locale" do
         command.call
         initiative = Decidim::Initiative.last
 
@@ -70,7 +68,7 @@ shared_examples 'create an initiative' do
         expect(initiative.description.keys).not_to be_empty
       end
 
-      it 'Voting interval is not set yet' do
+      it "Voting interval is not set yet" do
         command.call
         initiative = Decidim::Initiative.last
 

--- a/spec/shared/create_initiative_type_example.rb
+++ b/spec/shared/create_initiative_type_example.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-shared_examples 'create an initiative type' do
+shared_examples "create an initiative type" do
   let(:organization) { create(:organization) }
 
   let(:form) do
@@ -12,25 +12,23 @@ shared_examples 'create an initiative type' do
     )
   end
 
-  describe 'call' do
+  describe "call" do
     let(:form_params) do
       {
         title: Decidim::Faker::Localized.sentence(5),
         description: Decidim::Faker::Localized.sentence(25),
-        banner_image: Decidim::Dev.test_file('city2.jpeg', 'image/jpeg')
+        banner_image: Decidim::Dev.test_file("city2.jpeg", "image/jpeg")
       }
     end
 
-    let(:command) do
-      described_class.new(form)
-    end
+    let(:command) { described_class.new(form) }
 
-    describe 'when the form is not valid' do
+    describe "when the form is not valid" do
       before do
         expect(form).to receive(:invalid?).and_return(true)
       end
 
-      it 'broadcasts invalid' do
+      it "broadcasts invalid" do
         expect { command.call }.to broadcast(:invalid)
       end
 
@@ -41,12 +39,12 @@ shared_examples 'create an initiative type' do
       end
     end
 
-    describe 'when the form is valid' do
-      it 'broadcasts ok' do
+    describe "when the form is valid" do
+      it "broadcasts ok" do
         expect { command.call }.to broadcast(:ok)
       end
 
-      it 'creates a new initiative type' do
+      it "creates a new initiative type" do
         expect do
           command.call
         end.to change { Decidim::InitiativesType.count }.by(1)

--- a/spec/shared/create_initiative_type_scope_example.rb
+++ b/spec/shared/create_initiative_type_scope_example.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-shared_examples 'create an initiative type scope' do
+shared_examples "create an initiative type scope" do
   let(:organization) { create(:organization) }
   let(:scope) { create(:scope, organization: organization) }
   let(:initiative_type) { create(:initiatives_type, organization: organization) }
@@ -13,7 +13,7 @@ shared_examples 'create an initiative type scope' do
     )
   end
 
-  describe 'call' do
+  describe "call" do
     let(:form_params) do
       {
         supports_required: 1000,
@@ -21,16 +21,14 @@ shared_examples 'create an initiative type scope' do
       }
     end
 
-    let(:command) do
-      described_class.new(form)
-    end
+    let(:command) { described_class.new(form) }
 
-    describe 'when the form is not valid' do
+    describe "when the form is not valid" do
       before do
         expect(form).to receive(:invalid?).and_return(true)
       end
 
-      it 'broadcasts invalid' do
+      it "broadcasts invalid" do
         expect { command.call }.to broadcast(:invalid)
       end
 
@@ -41,12 +39,12 @@ shared_examples 'create an initiative type scope' do
       end
     end
 
-    describe 'when the form is valid' do
-      it 'broadcasts ok' do
+    describe "when the form is valid" do
+      it "broadcasts ok" do
         expect { command.call }.to broadcast(:ok)
       end
 
-      it 'creates a new initiative type scope' do
+      it "creates a new initiative type scope" do
         expect do
           command.call
         end.to change { Decidim::InitiativesTypeScope.count }.by(1)

--- a/spec/shared/tasks.rb
+++ b/spec/shared/tasks.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rake'
+require "rake"
 
 # Task names should be used in the top-level describe, with an optional
 # "rake "-prefix for better documentation. Both of these will work:
@@ -16,11 +16,11 @@ module TaskExampleGroup
   extend ActiveSupport::Concern
 
   included do
-    let(:task_name) { self.class.top_level_description.sub(/\Arake /, '') }
-    let(:tasks) { Rake::Task }
-
     # Make the Rake task available as `task` in your examples:
     subject(:task) { tasks[task_name] }
+
+    let(:task_name) { self.class.top_level_description.sub(/\Arake /, "") }
+    let(:tasks) { Rake::Task }
   end
 end
 

--- a/spec/shared/update_initiative_example.rb
+++ b/spec/shared/update_initiative_example.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-shared_examples 'update an initiative' do
+shared_examples "update an initiative" do
   let(:organization) { create(:organization) }
   let(:initiative) { create(:initiative, organization: organization) }
 
@@ -14,33 +14,31 @@ shared_examples 'update an initiative' do
     )
   end
 
-  describe 'call' do
+  describe "call" do
     let(:form_params) do
       {
-        title: { en: 'A reasonable initiative title' },
-        description: { en: 'A reasonable initiative description' },
-        signature_start_time: Date.today + 10.days,
-        signature_end_time: Date.today + 130.days,
-        signature_type: 'any',
+        title: { en: "A reasonable initiative title" },
+        description: { en: "A reasonable initiative description" },
+        signature_start_time: Time.zone.today + 10.days,
+        signature_end_time: Time.zone.today + 130.days,
+        signature_type: "any",
         type_id: initiative.type.id,
         decidim_scope_id: initiative.scope.id,
-        answer: { en: 'Measured answer' },
-        answer_url: 'http://decidim.org',
-        hashtag: 'update_initiative_example',
+        answer: { en: "Measured answer" },
+        answer_url: "http://decidim.org",
+        hashtag: "update_initiative_example",
         offline_votes: 1
       }
     end
 
-    let(:command) do
-      described_class.new(initiative, form, initiative.author)
-    end
+    let(:command) { described_class.new(initiative, form, initiative.author) }
 
-    describe 'when the form is not valid' do
+    describe "when the form is not valid" do
       before do
         expect(form).to receive(:invalid?).and_return(true)
       end
 
-      it 'broadcasts invalid' do
+      it "broadcasts invalid" do
         expect { command.call }.to broadcast(:invalid)
       end
 
@@ -53,25 +51,25 @@ shared_examples 'update an initiative' do
       end
     end
 
-    describe 'when the form is valid' do
-      it 'broadcasts ok' do
+    describe "when the form is valid" do
+      it "broadcasts ok" do
         expect { command.call }.to broadcast(:ok)
       end
 
-      it 'updates the initiative' do
+      it "updates the initiative" do
         command.call
         initiative.reload
 
-        expect(initiative.title['en']).to eq(form_params[:title][:en])
-        expect(initiative.description['en']).to eq(form_params[:description][:en])
-        expect(initiative.answer['en']).to eq(form_params[:answer][:en])
+        expect(initiative.title["en"]).to eq(form_params[:title][:en])
+        expect(initiative.description["en"]).to eq(form_params[:description][:en])
+        expect(initiative.answer["en"]).to eq(form_params[:answer][:en])
         expect(initiative.type.id).to eq(form_params[:type_id])
         expect(initiative.signature_type).to eq(form_params[:signature_type])
         expect(initiative.answer_url).to eq(form_params[:answer_url])
         expect(initiative.hashtag).to eq(form_params[:hashtag])
       end
 
-      it 'voting interval remains unchanged' do
+      it "voting interval remains unchanged" do
         command.call
         initiative.reload
 
@@ -80,20 +78,20 @@ shared_examples 'update an initiative' do
         end
       end
 
-      it 'offline votes remain unchanged' do
+      it "offline votes remain unchanged" do
         command.call
         initiative.reload
         expect(initiative.offline_votes).not_to eq(form_params[:offline_votes])
       end
 
-      context 'Administrator user' do
-        let(:administrator) { create(:user, :admin, organization: organization)}
+      context "Administrator user" do
+        let(:administrator) { create(:user, :admin, organization: organization) }
 
         let(:command) do
           described_class.new(initiative, form, administrator)
         end
 
-        it 'voting interval gets updated' do
+        it "voting interval gets updated" do
           command.call
           initiative.reload
 
@@ -102,7 +100,7 @@ shared_examples 'update an initiative' do
           end
         end
 
-        it 'offline votes gets updated' do
+        it "offline votes gets updated" do
           command.call
           initiative.reload
           expect(initiative.offline_votes).to eq(form_params[:offline_votes])

--- a/spec/shared/update_initiative_type_example.rb
+++ b/spec/shared/update_initiative_type_example.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-shared_examples 'update an initiative type' do
+shared_examples "update an initiative type" do
   let(:initiative_type) { create(:initiatives_type) }
 
   let(:form) do
@@ -12,25 +12,23 @@ shared_examples 'update an initiative type' do
     )
   end
 
-  describe 'call' do
+  describe "call" do
     let(:form_params) do
       {
         title: Decidim::Faker::Localized.sentence(5),
         description: Decidim::Faker::Localized.sentence(25),
-        banner_image: Decidim::Dev.test_file('city2.jpeg', 'image/jpeg')
+        banner_image: Decidim::Dev.test_file("city2.jpeg", "image/jpeg")
       }
     end
 
-    let(:command) do
-      described_class.new(initiative_type, form)
-    end
+    let(:command) { described_class.new(initiative_type, form) }
 
-    describe 'when the form is not valid' do
+    describe "when the form is not valid" do
       before do
         expect(form).to receive(:invalid?).and_return(true)
       end
 
-      it 'broadcasts invalid' do
+      it "broadcasts invalid" do
         expect { command.call }.to broadcast(:invalid)
       end
 
@@ -41,12 +39,12 @@ shared_examples 'update an initiative type' do
       end
     end
 
-    describe 'when the form is valid' do
-      it 'broadcasts ok' do
+    describe "when the form is valid" do
+      it "broadcasts ok" do
         expect { command.call }.to broadcast(:ok)
       end
 
-      it 'updates the initiative type' do
+      it "updates the initiative type" do
         command.call
 
         expect(initiative_type.title).to eq(form_params[:title])

--- a/spec/shared/update_initiative_type_scope_example.rb
+++ b/spec/shared/update_initiative_type_scope_example.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-shared_examples 'update an initiative type scope' do
+shared_examples "update an initiative type scope" do
   let(:initiatives_type_scope) { create(:initiatives_type_scope) }
   let(:scope) { create(:scope, organization: initiatives_type_scope.type.organization) }
 
@@ -22,12 +22,12 @@ shared_examples 'update an initiative type scope' do
       described_class.new(initiatives_type_scope, form)
     end
 
-    describe 'when the form is not valid' do
+    describe "when the form is not valid" do
       before do
         expect(form).to receive(:invalid?).and_return(true)
       end
 
-      it 'broadcasts invalid' do
+      it "broadcasts invalid" do
         expect { command.call }.to broadcast(:invalid)
       end
 
@@ -38,12 +38,12 @@ shared_examples 'update an initiative type scope' do
       end
     end
 
-    describe 'when the form is valid' do
-      it 'broadcasts ok' do
+    describe "when the form is valid" do
+      it "broadcasts ok" do
         expect { command.call }.to broadcast(:ok)
       end
 
-      it 'updates the initiative type scope' do
+      it "updates the initiative type scope" do
         command.call
 
         expect(initiatives_type_scope.supports_required).to eq(form_params[:supports_required])


### PR DESCRIPTION


#### :tophat: What? Why?

Vote button for guest users is only available when on-line voting is
enabled.

Fixed rubocop offenses.

Fixed test issues.

#### :pushpin: Related Issues
- Fixes #94 
