### PR TITLE
Make initiative authors automatically follow their initiatives

### DIFF
--- a/spec/shared/create_initiative_example.rb
+++ b/spec/shared/create_initiative_example.rb
@@ -74,6 +74,14 @@ shared_examples "create an initiative" do
 
         expect(initiative).not_to have_signature_interval_defined
       end
+
+      it "adds the author as follower" do
+        command.call do
+          on(:ok) do |assembly|
+            expect(author.follows?(assembly)).to be_true
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

Initiative authors will automatically follow their own initiatives.

#### :pushpin: Related Issues
- Related to https://github.com/decidim/decidim/issues/2334
