### PR TITLE
partially_translated_attribute replacement

### DIFF
--- a/app/mailers/decidim/initiatives/initiatives_mailer.rb
+++ b/app/mailers/decidim/initiatives/initiatives_mailer.rb
@@ -4,7 +4,9 @@ module Decidim
   module Initiatives
     # Mailer for initiatives engine.
     class InitiativesMailer < Decidim::ApplicationMailer
-      extend Decidim::Initiatives::PartialTranslationsHelper
+      include Decidim::TranslatableAttributes
+
+      add_template_helper Decidim::TranslatableAttributes
 
       # Notifies initiative creation
       def notify_creation(initiative)
@@ -13,8 +15,8 @@ module Decidim
 
         with_user(initiative.author) do
           @subject = I18n.t(
-            'decidim.initiatives.initiatives_mailer.creation_subject',
-            title: partially_translated_attribute(initiative.title)
+            "decidim.initiatives.initiatives_mailer.creation_subject",
+            title: translated_attribute(initiative.title)
           )
 
           mail(to: "#{initiative.author.name} <#{initiative.author.email}>", subject: @subject)
@@ -27,14 +29,14 @@ module Decidim
 
         with_user(user) do
           @subject = I18n.t(
-            'decidim.initiatives.initiatives_mailer.status_change_for',
-            title: partially_translated_attribute(initiative.title)
+            "decidim.initiatives.initiatives_mailer.status_change_for",
+            title: translated_attribute(initiative.title)
           )
 
           @body = I18n.t(
-            'decidim.initiatives.initiatives_mailer.status_change_body_for',
-            title: partially_translated_attribute(initiative.title),
-            state: I18n.t(initiative.state, scope: 'decidim.initiatives.admin_states')
+            "decidim.initiatives.initiatives_mailer.status_change_body_for",
+            title: translated_attribute(initiative.title),
+            state: I18n.t(initiative.state, scope: "decidim.initiatives.admin_states")
           )
 
           @link = initiative_url(initiative, host: @organization.host)
@@ -50,12 +52,12 @@ module Decidim
 
         with_user(user) do
           @subject = I18n.t(
-            'decidim.initiatives.initiatives_mailer.technical_validation_for',
-            title: partially_translated_attribute(initiative.title)
+            "decidim.initiatives.initiatives_mailer.technical_validation_for",
+            title: translated_attribute(initiative.title)
           )
           @body = I18n.t(
-            'decidim.initiatives.initiatives_mailer.technical_validation_body_for',
-            title: partially_translated_attribute(initiative.title)
+            "decidim.initiatives.initiatives_mailer.technical_validation_body_for",
+            title: translated_attribute(initiative.title)
           )
 
           mail(to: "#{user.name} <#{user.email}>", subject: @subject)
@@ -69,14 +71,14 @@ module Decidim
 
         with_user(user) do
           @body = I18n.t(
-            'decidim.initiatives.initiatives_mailer.progress_report_body_for',
-            title: partially_translated_attribute(initiative.title),
+            "decidim.initiatives.initiatives_mailer.progress_report_body_for",
+            title: translated_attribute(initiative.title),
             percentage: initiative.percentage
           )
 
           @subject = I18n.t(
-            'decidim.initiatives.initiatives_mailer.progress_report_for',
-            title: partially_translated_attribute(initiative.title)
+            "decidim.initiatives.initiatives_mailer.progress_report_for",
+            title: translated_attribute(initiative.title)
           )
 
           mail(to: "#{user.name} <#{user.email}>", subject: @subject)

--- a/app/views/decidim/initiatives/initiatives_mailer/notify_creation.html.erb
+++ b/app/views/decidim/initiatives/initiatives_mailer/notify_creation.html.erb
@@ -1,5 +1,5 @@
 <p>
-<%=t 'decidim.initiatives.initiatives_mailer.creation_subject', title: partially_translated_attribute(@initiative.title) %>.
+<%=t 'decidim.initiatives.initiatives_mailer.creation_subject', title: translated_attribute(@initiative.title) %>.
 <%= link_to t('decidim.initiatives.initiatives_mailer.more_information'), decidim.page_url('initiatives', host: @organization.host) %>
 </p>
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,11 +9,10 @@ services:
       - "3000:3000"
     volumes:
       - .:/code
-      - gems:/gems
+      - bundle:/usr/local/bundle
     environment:
       - DATABASE_HOST=pg
       - DATABASE_USERNAME=postgres
-      - GEM_HOME=/gems
     links:
       - pg
       - redis
@@ -27,6 +26,6 @@ services:
       - redis-data:/data
 volumes:
   dummy_app: {}
-  gems: {}
+  bundle: {}
   pg-data: {}
   redis-data: {}


### PR DESCRIPTION


#### :tophat: What? Why?

Partially translated attribute has been replaced by
translated attribute in all mailers.

#### :pushpin: Related Issues
- Related to #65 